### PR TITLE
Reformatted output, added file

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,14 +65,14 @@ WebpackEscapeHatchPlugin.prototype.apply = function (compiler) {
     if (stats.compilation.warnings.length > 0) {
       this.logger.warning('Warnings found during compilation:');
       stats.compilation.warnings.forEach((warning) => {
-        this.logger.warning(`${warning.message || warning}`);
+        this.logger.warning(`WARNING in ${warning.file}\n ${warning.message}`);
       });
     }
 
     if (stats.compilation.errors.length > 0) {
       this.logger.error('Errors found during compilation:');
       stats.compilation.errors.forEach((error) => {
-        this.logger.error(`${error.message || error}`);
+        this.logger.error(`ERROR in ${error.file}\n ${error.message}`);
       });
 
       isWatching = isWatching || compiler.options.watch;


### PR DESCRIPTION
- Currently there is no way to know which file had the error based on the output. This will add the file's full name to the output.
- Formatting slightly changed.
- [WebpackEscapeHatch] removed from each log as it is covered at the top.